### PR TITLE
deps: update to `bpmn-js-token-simulation@0.31.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "bpmn-js": "^9.0.3",
-        "bpmn-js-token-simulation": "^0.30.1",
+        "bpmn-js-token-simulation": "^0.31.0",
         "camunda-modeler-plugin-helpers": "^5.0.0",
         "copy-webpack-plugin": "^8.1.1",
         "min-dom": "^3.1.3",
@@ -384,9 +384,9 @@
       }
     },
     "node_modules/bpmn-js-token-simulation": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-token-simulation/-/bpmn-js-token-simulation-0.30.1.tgz",
-      "integrity": "sha512-KSHr3/G7mi8BA99SjsNdeNK0EG7m9Jkj31uMGB3WWG8XdKtkBQXKWXZ0mqQpCeyRZku7vnA0EAF5c4cY/dUa6Q==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-token-simulation/-/bpmn-js-token-simulation-0.31.0.tgz",
+      "integrity": "sha512-ux75/GEWyNJB1Ml+rjFf+QqP577BuOilu8lsvI88Fzfzjz0n0rCVqn8s36jaYaLvWL2lr4apHL9AZBKFBONadA==",
       "dev": true,
       "dependencies": {
         "inherits-browser": "^0.1.0",
@@ -2799,9 +2799,9 @@
       }
     },
     "bpmn-js-token-simulation": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-token-simulation/-/bpmn-js-token-simulation-0.30.1.tgz",
-      "integrity": "sha512-KSHr3/G7mi8BA99SjsNdeNK0EG7m9Jkj31uMGB3WWG8XdKtkBQXKWXZ0mqQpCeyRZku7vnA0EAF5c4cY/dUa6Q==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-token-simulation/-/bpmn-js-token-simulation-0.31.0.tgz",
+      "integrity": "sha512-ux75/GEWyNJB1Ml+rjFf+QqP577BuOilu8lsvI88Fzfzjz0n0rCVqn8s36jaYaLvWL2lr4apHL9AZBKFBONadA==",
       "dev": true,
       "requires": {
         "inherits-browser": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "devDependencies": {
     "bpmn-js": "^9.0.3",
-    "bpmn-js-token-simulation": "^0.30.1",
+    "bpmn-js-token-simulation": "^0.31.0",
     "camunda-modeler-plugin-helpers": "^5.0.0",
     "copy-webpack-plugin": "^8.1.1",
     "min-dom": "^3.1.3",


### PR DESCRIPTION
Closes #54